### PR TITLE
Add missing language entry

### DIFF
--- a/lang/en/diary.php
+++ b/lang/en/diary.php
@@ -345,6 +345,7 @@ $string['privacy:metadata:diary_entries:promptdatestop'] = 'The date the automat
 $string['privacy:metadata:diary_entries:prompttext'] = 'The text of the writing prompt used for auto-rating and feedback.';
 $string['privacy:metadata:diary_entries:rating'] = 'The numerical grade for this diary entry. Can be determined by scales/advancedgradingforms etc., but will always be converted back to a floating point number.';
 $string['privacy:metadata:diary_entries:teacher'] = 'The user ID of the person rating the entry.';
+$string['privacy:metadata:diary_entries:title'] = 'The title or description of this entry.';
 $string['privacy:metadata:diary_entries:text'] = 'The content of this entry.';
 $string['privacy:metadata:diary_entries:timecreated'] = 'Time the entry was created.';
 $string['privacy:metadata:diary_entries:timemarked'] = 'Time the entry was rated.';


### PR DESCRIPTION
Hello :)

Linking issue: https://github.com/drachels/moodle-mod_diary/issues/40

I was doing some testing of the plugin and noticed an error during in the language file causing unit tests to fail. This pull request will fix this issue.

```
1) core_privacy\privacy\provider_test::test_metadata_provider with data set "mod_diary" ('mod_diary', 'mod_diary\privacy\provider')
Expectation failed, debugging() was triggered.
Debugging: Invalid get_string() identifier: 'privacy:metadata:diary_entries:title' or component 'mod_diary'. Perhaps you are missing $string['privacy:metadata:diary_entries:title'] = ''; in mod/diary/lang/en/diary.php?
* line 356 of /lib/classes/string_manager_standard.php: call to debugging()
* line 7416 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
* line 163 of /privacy/tests/privacy/provider_test.php: call to get_string()
* line 1548 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to core_privacy\privacy\provider_test->test_metadata_provider()
* line 1154 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 80 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 728 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 904 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 675 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 653 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 144 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 97 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 97 of phpvfscomposer:///vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 118 of /vendor/bin/phpunit: call to include()
```