### PR TITLE
Turn off global search file indexing.

### DIFF
--- a/classes/search/activity.php
+++ b/classes/search/activity.php
@@ -40,21 +40,6 @@ class activity extends \core_search\base_activity {
      * @return bool
      */
     public function uses_file_indexing() {
-        return true;
-    }
-
-    /**
-     * Return the context info required to index files for
-     * this search area.
-     *
-     * @return array
-     */
-    public function get_search_fileareas() {
-        $fileareas =
-            [
-                'intro',
-                DIARY_INTROATTACHMENT_FILEAREA,
-            ]; // Fileareas.
-        return $fileareas;
+        return false;
     }
 }


### PR DESCRIPTION
the current implementation is broken due to the usage of an undefined constant.
turning this off and removing the broken function fixes this issue.

fixes https://github.com/drachels/moodle-mod_diary/issues/27