### PR TITLE
Push assesstimestart and assesstimefinish when resetting a course

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -607,7 +607,7 @@ function diary_reset_userdata($data) {
     if ($data->timeshift) {
         // Any changes to the list of dates that needs to be rolled should be same during course restore and course reset.
         // See MDL-9367.
-        shift_course_mod_dates('diary', ['timeopen', 'timeclose'], $data->timeshift, $data->courseid);
+        shift_course_mod_dates('diary', ['timeopen', 'timeclose', 'assesstimestart', 'assesstimefinish'], $data->timeshift, $data->courseid);
         $status[] = ['component' => $componentstr, 'item' => get_string('datechanged'), 'error' => false];
     }
 


### PR DESCRIPTION
Hi @drachels 

When resetting a course, the current function pushes back `timeopen` and `timeclose` only. It makes sense to push back `assesstimestart` and `assesstimefinish` accordingly as well. The PR does exactly that.

Please review and merge.

Regards,
Lai