### PR TITLE
removes unneccessary version check in *_supports() callback.

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -163,11 +163,7 @@ function diary_delete_instance($id) {
  */
 function diary_supports($feature) {
     global $CFG;
-    if ((int)$CFG->branch > 311) {
-        if ($feature === FEATURE_MOD_PURPOSE) {
-            return MOD_PURPOSE_COLLABORATION;
-        }
-    }
+
     switch ($feature) {
         case FEATURE_BACKUP_MOODLE2:
             return true;
@@ -189,6 +185,8 @@ function diary_supports($feature) {
             return true;
         case FEATURE_SHOW_DESCRIPTION:
             return true;
+        case FEATURE_MOD_PURPOSE:
+            return MOD_PURPOSE_COLLABORATION;
 
         default:
         return null;


### PR DESCRIPTION
`FEATURE_MOD_PURPOSE` was introduced in Moodle 4.0. this is not a backwards-compat breaking change, so no need to check the Moodle version here at all.

For reference, see https://moodledev.io/docs/4.1/devupdate#activity-icons

This fixes #48 