### PR TITLE
Issue #41 Add missing langstring entry

### DIFF
--- a/lang/en/diary.php
+++ b/lang/en/diary.php
@@ -345,6 +345,7 @@ $string['privacy:metadata:diary_entries:promptdatestop'] = 'The date the automat
 $string['privacy:metadata:diary_entries:prompttext'] = 'The text of the writing prompt used for auto-rating and feedback.';
 $string['privacy:metadata:diary_entries:rating'] = 'The numerical grade for this diary entry. Can be determined by scales/advancedgradingforms etc., but will always be converted back to a floating point number.';
 $string['privacy:metadata:diary_entries:teacher'] = 'The user ID of the person rating the entry.';
+$string['privacy:metadata:diary_entries:title'] = 'The title or description of this entry.';
 $string['privacy:metadata:diary_entries:text'] = 'The content of this entry.';
 $string['privacy:metadata:diary_entries:timecreated'] = 'Time the entry was created.';
 $string['privacy:metadata:diary_entries:timemarked'] = 'Time the entry was rated.';


### PR DESCRIPTION
Environment Details

* PHP 8.1
* MOODLE 4.5
Branch : master

How to recreate the issue?

1. Get the latest code master branch
2. Run a unit test `vendor/bin/phpunit admin/tool/dataprivacy/tests/metadata_registry_test.php`

Actual Output:

```
tool_dataprivacy\metadata_registry_test::test_get_registry_metadata_count
Unexpected debugging() call detected.
Debugging: Invalid get_string() identifier: 'privacy:metadata:diary_entries:title' or component 'mod_diary'. Perhaps you are missing $string['privacy:metadata:diary_entries:title'] = ''; in mod/diary/lang/en/diary.php?
* line 356 of /lib/classes/string_manager_standard.php: call to debugging()
* line 7013 of /lib/moodlelib.php: call to core_string_manager_standard->get_string()
* line 132 of /admin/tool/dataprivacy/classes/metadata_registry.php: call to get_string()
* line ? of unknownfile: call to tool_dataprivacy\metadata_registry->tool_dataprivacy\{closure}()
* line 129 of /admin/tool/dataprivacy/classes/metadata_registry.php: call to array_map()
* line 62 of /admin/tool/dataprivacy/classes/metadata_registry.php: call to tool_dataprivacy\metadata_registry->format_metadata()
* line ? of unknownfile: call to tool_dataprivacy\metadata_registry->tool_dataprivacy\{closure}()
* line 107 of /admin/tool/dataprivacy/classes/metadata_registry.php: call to array_map()
* line 35 of /admin/tool/dataprivacy/tests/metadata_registry_test.php: call to tool_dataprivacy\metadata_registry->get_registry_metadata()
* line 51 of /admin/tool/dataprivacy/tests/metadata_registry_test.php: call to tool_dataprivacy\metadata_registry_test->get_meta_data()
* line 1617 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to tool_dataprivacy\metadata_registry_test->test_get_registry_metadata_count()
* line 1223 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestCase->runTest()
* line 76 of /lib/phpunit/classes/advanced_testcase.php: call to PHPUnit\Framework\TestCase->runBare()
* line 729 of /vendor/phpunit/phpunit/src/Framework/TestResult.php: call to advanced_testcase->runBare()
* line 973 of /vendor/phpunit/phpunit/src/Framework/TestCase.php: call to PHPUnit\Framework\TestResult->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestCase->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 685 of /vendor/phpunit/phpunit/src/Framework/TestSuite.php: call to PHPUnit\Framework\TestSuite->run()
* line 651 of /vendor/phpunit/phpunit/src/TextUI/TestRunner.php: call to PHPUnit\Framework\TestSuite->run()
* line 146 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\TestRunner->run()
* line 99 of /vendor/phpunit/phpunit/src/TextUI/Command.php: call to PHPUnit\TextUI\Command->run()
* line 107 of /vendor/phpunit/phpunit/phpunit: call to PHPUnit\TextUI\Command::main()
* line 122 of /vendor/bin/phpunit: call to include()
```

Expected output: No errors related to `Debugging: Invalid get_string() identifier: 'privacy:metadata:diary_entries:title' or component 'mod_diary'. Perhaps you are missing $string['privacy:metadata:diary_entries:title'] = ''; in mod/diary/lang/en/diary.php?`




